### PR TITLE
feat: configure Prettier for code formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,37 @@
+# Dependencies
+node_modules/
+dist/
+build/
+.next/
+.nuxt/
+
+# Generated files
+*.min.js
+*.min.css
+coverage/
+.nyc_output/
+
+# Config files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Build outputs
+dist-ssr/
+*.local
+
+# Testing files
+.vitest/
+.coverage/
+
+# Logs
+logs
+*.log
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "endOfLine": "lf",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "jsxSingleQuote": false,
+  "bracketSameLine": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -106,7 +106,30 @@ To start the development server, run:
 npm run dev
 ```
 
-Open your browser and navigate to `http://localhost:3000` to see the application in action.
+Open your browser and navigate to `http://localhost:5173` to see the application in action.
+
+## 🧹 Code Formatting
+
+This project uses **Prettier** for consistent code style.
+
+### 🔧 Scripts
+
+```json
+"format": "prettier --write .",
+"format:check": "prettier --check ."
+```
+
+### 🛠 Usage
+
+| Command              | Description                                         |
+|----------------------|-----------------------------------------------------|
+| `npm run format`      | Formats the entire project based on `.prettierrc`   |
+| `npm run format:check`| Checks if files are correctly formatted (read-only) |
+
+### 💡 VSCode
+
+- Requires [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+- Auto-format on save is preconfigured in `.vscode/settings.json`
 
 ### Folder Structure
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,html}\""
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",


### PR DESCRIPTION
- Add .prettierrc with project formatting rules
- Add .prettierignore to exclude build files
- Configure VS Code settings for auto-format on save
- Update package.json with format scripts
- Update README with formatting documentation
- Update .gitignore